### PR TITLE
Update bundle.js, no longer creates default AmazonBraketSymbols for Qjs

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -3454,7 +3454,6 @@ Gate = function( params ){
 	this.index = Gate.index ++
 	
 	if( typeof this.symbol !== 'string' ) this.symbol = '?'
-	if( typeof this.symbolAmazonBraket !== 'string' ) this.symbolAmazonBraket = this.symbol.toLowerCase()
 	const parameters = Object.assign( {}, params.parameters )
 	this.parameters = parameters
 	


### PR DESCRIPTION
Update bundle.js to keep up with changes in Gate.js