### PR TITLE
Reduce width of palette on creation in a JupyterNotebook via braket()…

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -8170,10 +8170,12 @@ braket = function(){
 		circuit = new Q( args[0], args[1] )
 	}
 	container = document.createElement( 'div' )
-	container.appendChild( Editor.createPalette() )
+	let paletteEl = Editor.createPalette();
+	paletteEl.style.width = "50%";
+	container.appendChild( paletteEl );
 	container.appendChild( circuit.toDom() )
 	element.html( container )
-	document.querySelectorAll('.Q-circuit-palette').forEach( paletteEl => paletteEl.style.width = "50%") 
+
 
 	//  Weâ€™re going to take this SLOOOOOOOOWLY
 	//  because there are many potential things to debug.


### PR DESCRIPTION
Update braket() function to automatically reduce the width of a palette in a Jupyter Notebook. 